### PR TITLE
IMP-270: impl proto

### DIFF
--- a/proto/provider-disputes.thrift
+++ b/proto/provider-disputes.thrift
@@ -4,65 +4,29 @@ include "proto/domain.thrift"
 typedef string ID
 typedef string MIMEType
 
-struct Amount {
-    1: required domain.Amount value
-    2: required i16 exponent
-    3: optional string currencyName
-}
+service ProviderDisputesService {
 
-struct TransactionContext {
-    1: required ID transactionId
-    2: required domain.ProxyOptions terminalOptions
-    3: optional ID invoiceId
-    4: optional ID paymentId
+    DisputeCreatedResult CreateDispute (1: DisputeParams disputeParams)
+
+    DisputeStatusResult CheckDisputeStatus (1: DisputeContext disputeContext)
+
 }
 
 struct DisputeParams {
     1: required TransactionContext transactionContext
     2: required list<Attachment> attachments
     3: optional Amount amount
-    4: optional ID requisiteId
-    5: optional string reason
+    4: optional string reason
+}
+
+union DisputeCreatedResult {
+    1: DisputeCreatedSuccessResult successResult
+    2: DisputeCreatedFailResult failResult
 }
 
 struct DisputeContext {
     1: required ID disputeId
     2: required domain.ProxyOptions terminalOptions
-}
-
-union Attachment {
-    1: Base64EncodedAttachment base64EncodedAttachment
-}
-
-struct Base64EncodedAttachment {
-    1: required string base64EncodedSource
-    2: optional MIMEType mimeType
-    3: optional string name
-}
-
-union TransactionResult {
-    1: TransactionStatusResult statusResult
-    2: domain.Failure failure
-}
-
-union TransactionStatusResult {
-    1: TransactionStatusSuccessResult statusSuccess
-    2: TransactionStatusFailResult statusFail
-}
-
-struct TransactionStatusFailResult {}
-struct TransactionStatusSuccessResult {
-    1: optional Amount changedAmount
-}
-
-union DisputeResult {
-    1: DisputeCreatedResult result
-    2: DisputeStatusResult statusResult
-    3: domain.Failure failure
-}
-
-struct DisputeCreatedResult {
-    1: required ID disputeId
 }
 
 union DisputeStatusResult {
@@ -71,33 +35,43 @@ union DisputeStatusResult {
     3: DisputeStatusFailResult statusFail
 }
 
+struct TransactionContext {
+    1: required ID providerTrxId
+    2: required domain.ProxyOptions terminalOptions
+    3: optional ID invoiceId
+    4: optional ID paymentId
+}
+
+union Attachment {
+    1: Base64EncodedAttachment base64EncodedAttachment
+}
+
+struct DisputeCreatedSuccessResult {
+    1: required ID disputeId
+}
+
+struct DisputeCreatedFailResult {
+    1: required domain.Failure failure
+}
+
+struct DisputeStatusSuccessResult {
+    1: optional Amount changedAmount
+}
+
 struct DisputeStatusPendingResult {}
-struct DisputeStatusSuccessResult {}
-struct DisputeStatusFailResult {}
 
-struct DisputeCallback {
-    1: optional ID transactionId
-    2: optional TransactionStatusResult transactionStatusResult
-    3: optional ID disputeId
-    4: optional DisputeStatusResult disputeStatusResult
-    5: optional Amount amount
-    6: optional string reason
+struct DisputeStatusFailResult {
+    1: required domain.Failure failure
 }
 
-exception MethodNotSupported {}
-
-service ProviderDisputesService {
-
-    TransactionResult CheckTransactionStatus (1: TransactionContext transactionContext)
-
-    DisputeResult CreateDispute (1: DisputeParams disputeParams)
-
-    DisputeResult CheckDisputeStatus (1: DisputeContext disputeContext) throws (1: MethodNotSupported ex);
-
+struct Amount {
+    1: required domain.Amount value
+    2: required i16 exponent
+    3: optional string currencyName
 }
 
-service ProviderDisputesCallbackService {
-
-    void HandleCallback (1: DisputeCallback disputeCallback)
-
+struct Base64EncodedAttachment {
+    1: required string base64EncodedSource
+    2: optional MIMEType mimeType
+    3: optional string name
 }

--- a/proto/provider-disputes.thrift
+++ b/proto/provider-disputes.thrift
@@ -1,2 +1,110 @@
 namespace java dev.vality.disputes
 include "proto/domain.thrift"
+
+typedef string ID
+
+struct Amount {
+    1: required domain.Amount value
+    2: required i16 exponent
+    3: optional string currencyName
+}
+
+struct TransactionContext {
+    1: required ID transactionId
+    2: required domain.ProxyOptions terminalOptions
+    3: optional ID invoiceId
+    4: optional ID paymentId
+}
+
+struct DisputeParams {
+    1: required TransactionContext transactionContext
+    2: required list<Check> checks
+    3: optional Amount amount
+    4: optional ID requisiteId
+    5: optional string reason
+}
+
+struct DisputeContext {
+    1: required ID disputeId
+    2: required domain.ProxyOptions terminalOptions
+}
+
+union Check {
+    1: Base64EncodedCheck base64EncodedCheck
+}
+
+struct Base64EncodedCheck {
+    1: required string base64EncodedSource
+    2: optional CheckType checkType
+    3: optional string name
+}
+
+union CheckType {
+    1: CheckSourceTypeJpg jpg
+    2: CheckSourceTypePng png
+    3: CheckSourceTypePdf pdf
+}
+
+struct CheckSourceTypePng {}
+struct CheckSourceTypeJpg {}
+struct CheckSourceTypePdf {}
+
+union TransactionResult {
+    1: TransactionStatusResult statusResult
+    2: domain.Failure failure
+}
+
+union TransactionStatusResult {
+    1: TransactionStatusSuccessResult statusSuccess
+    2: TransactionStatusFailResult statusFail
+}
+
+struct TransactionStatusFailResult {}
+struct TransactionStatusSuccessResult {
+    1: optional Amount changedAmount
+}
+
+union DisputeResult {
+    1: DisputeCreatedResult result
+    2: DisputeStatusResult statusResult
+    3: domain.Failure failure
+}
+
+struct DisputeCreatedResult {
+    1: required ID disputeId
+}
+
+union DisputeStatusResult {
+    1: DisputeStatusPendingResult pendingSuccess
+    2: DisputeStatusSuccessResult statusSuccess
+    3: DisputeStatusFailResult statusFail
+}
+
+struct DisputeStatusPendingResult {}
+struct DisputeStatusSuccessResult {}
+struct DisputeStatusFailResult {}
+
+struct DisputeCallback {
+    1: optional ID transactionId
+    2: optional TransactionStatusResult transactionStatusResult
+    3: optional ID disputeId
+    4: optional DisputeStatusResult disputeStatusResult
+}
+
+exception MethodNotSupported {}
+
+service ProviderDisputesService {
+
+    TransactionResult CheckTransactionStatus (1: TransactionContext transactionContext)
+
+    DisputeResult CreateDispute (1: DisputeParams disputeParams)
+
+    DisputeResult CheckDisputeStatus (1: DisputeContext disputeContext) throws (1: MethodNotSupported ex);
+
+}
+
+service ProviderDisputesCallbackService {
+
+    void HandleCallback (1: DisputeCallback disputeCallback)
+
+}

--- a/proto/provider-disputes.thrift
+++ b/proto/provider-disputes.thrift
@@ -2,6 +2,7 @@ namespace java dev.vality.disputes
 include "proto/domain.thrift"
 
 typedef string ID
+typedef string MIMEType
 
 struct Amount {
     1: required domain.Amount value
@@ -18,7 +19,7 @@ struct TransactionContext {
 
 struct DisputeParams {
     1: required TransactionContext transactionContext
-    2: required list<Check> checks
+    2: required list<Attachment> attachments
     3: optional Amount amount
     4: optional ID requisiteId
     5: optional string reason
@@ -29,25 +30,15 @@ struct DisputeContext {
     2: required domain.ProxyOptions terminalOptions
 }
 
-union Check {
-    1: Base64EncodedCheck base64EncodedCheck
+union Attachment {
+    1: Base64EncodedAttachment base64EncodedAttachment
 }
 
-struct Base64EncodedCheck {
+struct Base64EncodedAttachment {
     1: required string base64EncodedSource
-    2: optional CheckType checkType
+    2: optional MIMEType mimeType
     3: optional string name
 }
-
-union CheckType {
-    1: CheckSourceTypeJpg jpg
-    2: CheckSourceTypePng png
-    3: CheckSourceTypePdf pdf
-}
-
-struct CheckSourceTypePng {}
-struct CheckSourceTypeJpg {}
-struct CheckSourceTypePdf {}
 
 union TransactionResult {
     1: TransactionStatusResult statusResult
@@ -89,6 +80,8 @@ struct DisputeCallback {
     2: optional TransactionStatusResult transactionStatusResult
     3: optional ID disputeId
     4: optional DisputeStatusResult disputeStatusResult
+    5: optional Amount amount
+    6: optional string reason
 }
 
 exception MethodNotSupported {}


### PR DESCRIPTION
```
if [vality] deposit status == fail
  1 кейс - check [provider] deposit status = fail -> create [provider] dispute -> check [provider] deposit status = success (changed), ignore [provider] dispute status (= success) -> [vality] deposit status = success (changed) -> return [vality] dispute status = success
  2 кейс - check [provider] deposit status = success -> ignore create [provider] dispute -> [vality] deposit status = success (changed) -> return [vality] dispute status = success
  3 кейс - check [provider] deposit status = fail -> create [provider] dispute -> check [provider] deposit status = fail -> check [provider] dispute status = fail (trigger 'stop pooling') -> [vality] deposit status = fail -> return [vality] dispute status = fail
  4 кейс - check [provider] deposit status = 500 -> call support
```
схема
![image](https://github.com/valitydev/provider-disputes-proto/assets/19729841/8b0eab2f-6195-4432-aad8-b430a7f87927)
